### PR TITLE
Update vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [{ "source": "(.*)", "destination": "/api" }],
   "regions": ["bom1"],
+  "outputDirectory": "src",
   "headers": [
     {
       "source": "(.*)",


### PR DESCRIPTION
Override outputDirectory to `src` 
Current vercel deployment fails since vercel expects default output directory to be `public`
